### PR TITLE
(fix) Wallet failing to connect issue

### DIFF
--- a/src/components/common/Wallet/ConnectWallet.tsx
+++ b/src/components/common/Wallet/ConnectWallet.tsx
@@ -38,7 +38,7 @@ export function ConnectWallet() {
       try {
         // Create the SIWE message
         const messageObject = {
-          domain: window.location.host,
+          domain: window.location.origin,
           address: getAddress(_address),
           uri: window.location.origin,
           version: '1',

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -4,9 +4,10 @@ export async function verifySiweSignature(message: string, signature: string, no
   try {
     const siwe = new SiweMessage(JSON.parse(message));
 
+    const domain = process.env.NEXT_PUBLIC_APP_URL || 'localhost:3000';
     const result = await siwe.verify({
       signature,
-      domain: process.env.NEXT_PUBLIC_APP_URL || 'localhost:3000',
+      domain: domain.includes('://') ? domain : `http://${domain}`,
       nonce
     });
 


### PR DESCRIPTION
This PR aims to fix the wallet connect issue:

- The SIWE verification was failing because the domain in the SIWE message did not match what the server-side verification expected. The client was sending localhost:3000, while the server expected http://localhost:3000.
- This was resolved by updating the client-side message creation in src/components/common/Wallet/ConnectWallet.tsx to use window.location.origin for both the domain and uri fields, ensuring the protocol is included.
- The server-side verification in src/lib/auth.ts was also updated to prepend http:// to the domain if it was missing, providing a more robust solution.