### PR TITLE
Feat - Added tab switch in the repo page

### DIFF
--- a/src/app/demo/[id]/page.tsx
+++ b/src/app/demo/[id]/page.tsx
@@ -97,49 +97,47 @@ export default function DemoRepositoryPage() {
       {/* Tab switch implementation */}
       <div className='mt-8 max-w-5xl mx-auto'>
         <Tabs defaultValue='leader-board' className='w-full'>
-          <TabsList className='grid w-full grid-cols-4 bg-transparent h-auto p-0 gap-0'>
+          <TabsList className='grid w-2xl grid-cols-4 bg-transparent h-auto p-0 gap-0'>
             <TabsTrigger
               value='leader-board'
-              className='relative bg-transparent border-0 rounded-none px-4 py-3 text-gray-600 hover:text-gray-900 data-[state=active]:bg-transparent data-[state=active]:text-blue-600 data-[state=active]:shadow-none data-[state=active]:after:absolute data-[state=active]:after:bottom-0 data-[state=active]:after:left-0 data-[state=active]:after:right-0 data-[state=active]:after:h-0.5 data-[state=active]:after:bg-blue-600'
+              className='relative bg-transparent border-0 rounded-none px-4 py-3 text-gray-600 hover:text-gray-900 data-[state=active]:bg-transparent data-[state=active]:text-primary data-[state=active]:shadow-none data-[state=active]:after:absolute data-[state=active]:after:bottom-0 data-[state=active]:after:left-0 data-[state=active]:after:right-0 data-[state=active]:after:h-0.5 data-[state=active]:after:bg-primary hover:cursor-pointer'
             >
               Leader Board
             </TabsTrigger>
             <TabsTrigger
               value='discussion'
-              className='relative bg-transparent border-0 rounded-none px-4 py-3 text-gray-600 hover:text-gray-900 data-[state=active]:bg-transparent data-[state=active]:text-blue-600 data-[state=active]:shadow-none data-[state=active]:after:absolute data-[state=active]:after:bottom-0 data-[state=active]:after:left-0 data-[state=active]:after:right-0 data-[state=active]:after:h-0.5 data-[state=active]:after:bg-blue-600'
+              className='relative bg-transparent border-0 rounded-none px-4 py-3 text-gray-600 hover:text-gray-900 data-[state=active]:bg-transparent data-[state=active]:text-primary data-[state=active]:shadow-none data-[state=active]:after:absolute data-[state=active]:after:bottom-0 data-[state=active]:after:left-0 data-[state=active]:after:right-0 data-[state=active]:after:h-0.5 data-[state=active]:after:bg-primary hover:cursor-pointer'
             >
               Discussion
             </TabsTrigger>
             <TabsTrigger
               value='socials'
-              className='relative bg-transparent border-0 rounded-none px-4 py-3 text-gray-600 hover:text-gray-900 data-[state=active]:bg-transparent data-[state=active]:text-blue-600 data-[state=active]:shadow-none data-[state=active]:after:absolute data-[state=active]:after:bottom-0 data-[state=active]:after:left-0 data-[state=active]:after:right-0 data-[state=active]:after:h-0.5 data-[state=active]:after:bg-blue-600'
+              className='relative bg-transparent border-0 rounded-none px-4 py-3 text-gray-600 hover:text-gray-900 data-[state=active]:bg-transparent data-[state=active]:text-primary data-[state=active]:shadow-none data-[state=active]:after:absolute data-[state=active]:after:bottom-0 data-[state=active]:after:left-0 data-[state=active]:after:right-0 data-[state=active]:after:h-0.5 data-[state=active]:after:bg-primary hover:cursor-pointer'
             >
               Socials
             </TabsTrigger>
             <TabsTrigger
               value='about'
-              className='relative bg-transparent border-0 rounded-none px-4 py-3 text-gray-600 hover:text-gray-900 data-[state=active]:bg-transparent data-[state=active]:text-blue-600 data-[state=active]:shadow-none data-[state=active]:after:absolute data-[state=active]:after:bottom-0 data-[state=active]:after:left-0 data-[state=active]:after:right-0 data-[state=active]:after:h-0.5 data-[state=active]:after:bg-blue-600'
+              className='relative bg-transparent border-0 rounded-none px-4 py-3 text-gray-600 hover:text-gray-900 data-[state=active]:bg-transparent data-[state=active]:text-primary data-[state=active]:shadow-none data-[state=active]:after:absolute data-[state=active]:after:bottom-0 data-[state=active]:after:left-0 data-[state=active]:after:right-0 data-[state=active]:after:h-0.5 data-[state=active]:after:bg-primary hover:cursor-pointer'
             >
               About Repository
             </TabsTrigger>
           </TabsList>
 
-          <div className='border-b border-gray-200 mb-6'></div>
-
           <TabsContent value='leader-board' className='mt-0'>
-            <div>Leader Board Content</div>
+            <div className='border rounded-md p-4 shadow-xs'>Leader Board Content</div>
           </TabsContent>
 
           <TabsContent value='discussion' className='mt-0'>
-            <div>Discussion Content</div>
+            <div className='border rounded-md p-4 shadow-xs'>Discussion Content</div>
           </TabsContent>
 
           <TabsContent value='socials' className='mt-0'>
-            <div>Socials Content</div>
+            <div className='border rounded-md p-4 shadow-xs'>Socials Content</div>
           </TabsContent>
 
           <TabsContent value='about' className='mt-0'>
-            <div>About Repository Content</div>
+            <div className='border rounded-md p-4 shadow-xs'>About Repository Content</div>
           </TabsContent>
         </Tabs>
       </div>

--- a/src/components/common/RepoSummary.tsx
+++ b/src/components/common/RepoSummary.tsx
@@ -2,17 +2,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { cn } from '@/lib/utils';
-import {
-  Coins,
-  FileText,
-  GitFork,
-  Globe,
-  Heart,
-  Star,
-  Github,
-  TrendingUp,
-  VerifiedIcon
-} from 'lucide-react';
+import { Coins, FileText, GitFork, Globe, Heart, Star, Github, TrendingUp, VerifiedIcon } from 'lucide-react';
 import Image from 'next/image';
 
 export interface RepoSummaryProps {
@@ -144,15 +134,15 @@ const RepoSummary: React.FC<RepoSummaryProps> = ({
 
               {/* Links */}
               <div className='flex items-center gap-4'>
-                <Github className='w-4 h-4 text-muted-foreground' />
-                <Globe className='w-4 h-4 text-muted-foreground' />
-                <FileText className='w-4 h-4 text-muted-foreground' />
+                <Github className='w-4 h-4 text-muted-foreground hover:cursor-pointer hover:text-primary hover:fill-accent' />
+                <Globe className='w-4 h-4 text-muted-foreground hover:cursor-pointer hover:text-primary hover:fill-accent' />
+                <FileText className='w-4 h-4 text-muted-foreground hover:cursor-pointer hover:text-primary hover:fill-accent' />
               </div>
             </div>
           </div>
         </div>
         <div className='grid grid-cols-4 gap-4'>
-          <Card className='p-6 flex flex-col items-center text-center bg-card border-border rounded-xl'>
+          <Card className='p-6 flex flex-col items-center text-center'>
             <div className='mb-4'>
               <Coins className='w-6 h-6 text-muted-foreground' />
             </div>
@@ -160,7 +150,7 @@ const RepoSummary: React.FC<RepoSummaryProps> = ({
             <div className='text-sm text-muted-foreground'>Total Votes</div>
           </Card>
 
-          <Card className='p-6 flex flex-col items-center text-center bg-card border-border rounded-xl'>
+          <Card className='p-6 flex flex-col items-center text-center'>
             <div className='mb-4'>
               <Star className='w-6 h-6 text-muted-foreground' />
             </div>
@@ -168,7 +158,7 @@ const RepoSummary: React.FC<RepoSummaryProps> = ({
             <div className='text-sm text-muted-foreground'>Github Stars</div>
           </Card>
 
-          <Card className='p-6 flex flex-col items-center text-center bg-card border-border rounded-xl'>
+          <Card className='p-6 flex flex-col items-center text-center'>
             <div className='mb-4'>
               <GitFork className='w-6 h-6 text-muted-foreground' />
             </div>
@@ -176,7 +166,7 @@ const RepoSummary: React.FC<RepoSummaryProps> = ({
             <div className='text-sm text-muted-foreground'>Forks</div>
           </Card>
 
-          <Card className='p-6 flex flex-col items-center text-center bg-card border-border rounded-xl'>
+          <Card className='p-6 flex flex-col items-center text-center'>
             <div className='mb-4'>
               <TrendingUp className='w-6 h-6 text-muted-foreground' />
             </div>


### PR DESCRIPTION
issue #51 

added tabs in the repo details page

<img width="1067" height="737" alt="image" src="https://github.com/user-attachments/assets/9aae1626-e8f7-4c12-92ea-cc98ca631b3a" />

reference photo

<img width="979" height="555" alt="image" src="https://github.com/user-attachments/assets/ae722bea-7f5d-47c4-a58d-16b71ad782b0" />

