### PR TITLE
feat: Implement toggleFavorite action

### DIFF
--- a/src/actions/repository/toggleFavorite/action.ts
+++ b/src/actions/repository/toggleFavorite/action.ts
@@ -1,0 +1,16 @@
+'use server';
+
+import { authActionClient } from '@/lib/actions';
+import { toggleFavorite } from './logic';
+import { toggleFavoriteSchema } from './schema';
+
+export const toggleFavoriteAction = authActionClient
+  .inputSchema(toggleFavoriteSchema)
+  .action(async ({ parsedInput, ctx }) => {
+    try {
+      const result = await toggleFavorite(parsedInput, ctx.session.userId);
+      return result;
+    } catch (error) {
+      throw new Error('Failed to toggle favorite', { cause: error });
+    }
+  });

--- a/src/actions/repository/toggleFavorite/index.ts
+++ b/src/actions/repository/toggleFavorite/index.ts
@@ -1,0 +1,5 @@
+export { toggleFavoriteAction } from './action';
+export { toggleFavorite } from './logic';
+export { toggleFavoriteSchema } from './schema';
+export type { ToggleFavoriteInput } from './schema';
+export type { ToggleFavoriteResult } from './logic';

--- a/src/actions/repository/toggleFavorite/logic.ts
+++ b/src/actions/repository/toggleFavorite/logic.ts
@@ -1,0 +1,51 @@
+import { prisma } from '@/lib/prisma';
+import { ToggleFavoriteInput } from './schema';
+
+export type ToggleFavoriteResult = {
+  isFavorited: boolean;
+  repositoryId: string;
+};
+
+export async function toggleFavorite(
+  input: ToggleFavoriteInput,
+  userId: string
+): Promise<ToggleFavoriteResult> {
+  const { repositoryId } = input;
+
+  // First, check if the user already has this repository in favorites
+  const existingFavorite = await prisma.userFavorite.findUnique({
+    where: {
+      userId_repositoryId: {
+        userId,
+        repositoryId
+      }
+    }
+  });
+
+  // If favorite exists, remove it
+  if (existingFavorite) {
+    await prisma.userFavorite.delete({
+      where: {
+        id: existingFavorite.id
+      }
+    });
+
+    return {
+      isFavorited: false,
+      repositoryId
+    };
+  }
+
+  // If favorite doesn't exist, create it
+  await prisma.userFavorite.create({
+    data: {
+      userId,
+      repositoryId
+    }
+  });
+
+  return {
+    isFavorited: true,
+    repositoryId
+  };
+}

--- a/src/actions/repository/toggleFavorite/logic.ts
+++ b/src/actions/repository/toggleFavorite/logic.ts
@@ -1,51 +1,36 @@
 import { prisma } from '@/lib/prisma';
+import { Prisma } from '@prisma/client';
 import { ToggleFavoriteInput } from './schema';
 
 export type ToggleFavoriteResult = {
   isFavorited: boolean;
   repositoryId: string;
 };
-
 export async function toggleFavorite(
   input: ToggleFavoriteInput,
   userId: string
 ): Promise<ToggleFavoriteResult> {
   const { repositoryId } = input;
-
-  // First, check if the user already has this repository in favorites
-  const existingFavorite = await prisma.userFavorite.findUnique({
-    where: {
-      userId_repositoryId: {
-        userId,
-        repositoryId
-      }
-    }
-  });
-
-  // If favorite exists, remove it
-  if (existingFavorite) {
+  try {
+    // Try to remove existing favorite (atomic on composite key)
     await prisma.userFavorite.delete({
-      where: {
-        id: existingFavorite.id
-      }
+      where: { userId_repositoryId: { userId, repositoryId } }
     });
-
-    return {
-      isFavorited: false,
-      repositoryId
-    };
-  }
-
-  // If favorite doesn't exist, create it
-  await prisma.userFavorite.create({
-    data: {
-      userId,
-      repositoryId
+    return { isFavorited: false, repositoryId };
+  } catch (err) {
+    // Not found => create; any other error => rethrow
+    if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2025') {
+      try {
+        await prisma.userFavorite.create({ data: { userId, repositoryId } });
+        return { isFavorited: true, repositoryId };
+      } catch (e) {
+        // Concurrent create by another request
+        if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === 'P2002') {
+          return { isFavorited: true, repositoryId };
+        }
+        throw e;
+      }
     }
-  });
-
-  return {
-    isFavorited: true,
-    repositoryId
-  };
+    throw err;
+  }
 }

--- a/src/actions/repository/toggleFavorite/schema.ts
+++ b/src/actions/repository/toggleFavorite/schema.ts
@@ -1,0 +1,7 @@
+import * as z from 'zod';
+
+export const toggleFavoriteSchema = z.object({
+  repositoryId: z.string().uuid({ message: 'Please provide a valid repository ID' })
+});
+
+export type ToggleFavoriteInput = z.infer<typeof toggleFavoriteSchema>;


### PR DESCRIPTION
feat: Implement Repository Favorite Toggle

- Add server action to toggle repository favorites
- Create logic to add or remove user favorites
- Include schema validation with Zod
- Return favorite status for UI updates
- Ensure authenticated users only can favorite repositories

This feature enables users to like/favorite repositories and supports the favorite listing functionality in the UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * You can now favorite or unfavorite repositories with a single action; the UI updates instantly.
  * Favorite status is saved to your account and persists across sessions for easier access to repos you care about.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->