### PR TITLE
refactor: Update Popover and Select components to support asChild prop

### DIFF
--- a/src/components/common/Actions.tsx
+++ b/src/components/common/Actions.tsx
@@ -7,7 +7,7 @@ export function Actions() {
   return (
     <div className='flex items-center gap-4'>
       <Popover>
-        <PopoverTrigger>
+        <PopoverTrigger asChild>
           <Button variant='outline' size='icon'>
             <Bell className='h-4 w-4' />
           </Button>

--- a/src/components/common/Filter.tsx
+++ b/src/components/common/Filter.tsx
@@ -10,19 +10,19 @@ export interface FilterProps {
 }
 
 export function Filter({ onApply }: FilterProps) {
-  const [selectedTag, setSelectedTag] = useState('');
+  const [selectedTag, setSelectedTag] = useState('all');
   const [org, setOrg] = useState('');
   const [maintainer, setMaintainer] = useState('');
   const [onlyFeatured, setOnlyFeatured] = useState(false);
 
   const handleApply = () => {
     if (onApply) {
-      onApply({ selectedTag, org, maintainer, onlyFeatured });
+      onApply({ selectedTag: selectedTag === 'all' ? '' : selectedTag, org, maintainer, onlyFeatured });
     }
   };
 
   return (
-    <Card className="space-y-4 p-4">
+    <Card className="space-y-4 p-4 border-none shadow-none">
       <div className="space-y-2">
         <Label htmlFor="tag">Tag</Label>
         <Select value={selectedTag} onValueChange={setSelectedTag}>
@@ -30,7 +30,7 @@ export function Filter({ onApply }: FilterProps) {
             <SelectValue placeholder="All" />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="">All</SelectItem>
+            <SelectItem value="all">All</SelectItem>
             <SelectItem value="frontend">Frontend</SelectItem>
             <SelectItem value="backend">Backend</SelectItem>
             <SelectItem value="devops">DevOps</SelectItem>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -46,11 +46,12 @@ function Button({
     asChild?: boolean
   }) {
   const Comp = asChild ? Slot : "button"
-
   return (
     <Comp
       data-slot="button"
       className={cn(buttonVariants({ variant, size, className }))}
+      // Only set type if rendering a native button
+      {...(!asChild && { type: "button" })}
       {...props}
     />
   )

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -12,9 +12,12 @@ function Popover({
 }
 
 function PopoverTrigger({
+  asChild = false,
   ...props
-}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
-  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
+}: React.ComponentProps<typeof PopoverPrimitive.Trigger> & { asChild?: boolean }) {
+  return (
+    <PopoverPrimitive.Trigger asChild={asChild} data-slot="popover-trigger" {...props} />
+  )
 }
 
 function PopoverContent({

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -28,26 +28,29 @@ function SelectTrigger({
   className,
   size = "default",
   children,
+  asChild = false,
   ...props
-}: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
-  size?: "sm" | "default"
-}) {
-  return (
-    <SelectPrimitive.Trigger
-      data-slot="select-trigger"
-      data-size={size}
-      className={cn(
-        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-        className
-      )}
-      {...props}
-    >
-      {children}
-      <SelectPrimitive.Icon asChild>
-        <ChevronDownIcon className="size-4 opacity-50" />
-      </SelectPrimitive.Icon>
-    </SelectPrimitive.Trigger>
-  )
+  }: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
+    size?: "sm" | "default"
+    asChild?: boolean
+  }) {
+    return (
+      <SelectPrimitive.Trigger
+        asChild={asChild}
+        data-slot="select-trigger"
+        data-size={size}
+        className={cn(
+          "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        <SelectPrimitive.Icon asChild>
+          <ChevronDownIcon className="size-4 opacity-50" />
+        </SelectPrimitive.Icon>
+      </SelectPrimitive.Trigger>
+    )
 }
 
 function SelectContent({


### PR DESCRIPTION
This PR fixes the error that was caused because of nested buttons

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Improved popover and select triggers to work seamlessly when wrapping custom elements, enabling greater composability.

- UX/UI
  - “All” is now the default tag in Filters, with clearer handling when applying.
  - Updated filter card styling to remove borders and shadows for a cleaner look.

- Bug Fixes
  - Button no longer forces a type attribute onto non-button elements when rendered via wrappers, preventing unintended behavior in complex layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->