### PR TITLE
feat: Add action for all-time top repositories

### DIFF
--- a/src/actions/repository/getTopReposAllTime/action.ts
+++ b/src/actions/repository/getTopReposAllTime/action.ts
@@ -1,0 +1,11 @@
+'use server';
+
+import { actionClient } from '@/lib/actions';
+import { getTopReposAllTime } from './logic';
+import { getTopReposAllTimeSchema } from './schema';
+
+export const getTopReposAllTimeAction = actionClient
+  .inputSchema(getTopReposAllTimeSchema)
+  .action(async ({ parsedInput }) => {
+    return getTopReposAllTime(parsedInput.limit);
+  });

--- a/src/actions/repository/getTopReposAllTime/logic.ts
+++ b/src/actions/repository/getTopReposAllTime/logic.ts
@@ -1,0 +1,94 @@
+'use server';
+
+import { prisma } from '@/lib/db';
+import { Decimal } from '@prisma/client/runtime/library';
+
+export type TopRepoAllTime = {
+  id: string;
+  name: string | null;
+  owner: string | null;
+  title: string;
+  description: string;
+  githubUrl: string;
+  websiteUrl: string | null;
+  docsUrl: string | null;
+  logoUrl: string | null;
+  tags: string[];
+  githubStars: number;
+  githubForks: number;
+  isVerified: boolean;
+  submitter: {
+    walletAddress: string;
+  };
+  totalVotes: number;
+  totalTokenAmount: Decimal;
+  uniqueVoters: number;
+};
+
+export type GetTopReposAllTimeResult = {
+  repositories: TopRepoAllTime[];
+};
+
+export const getTopReposAllTime = async (limit: number = 10): Promise<GetTopReposAllTimeResult> => {
+  const repositories = await prisma.repository.findMany({
+    select: {
+      id: true,
+      name: true,
+      owner: true,
+      title: true,
+      description: true,
+      githubUrl: true,
+      websiteUrl: true,
+      docsUrl: true,
+      logoUrl: true,
+      tags: true,
+      githubStars: true,
+      githubForks: true,
+      isVerified: true,
+      submitter: {
+        select: {
+          walletAddress: true
+        }
+      },
+      votes: {
+        select: {
+          userId: true,
+          tokenAmount: true
+        }
+      }
+    }
+  });
+
+  const repositoriesWithStats = repositories.map((repo) => {
+    const stats = repo.votes.reduce(
+      (acc, vote) => {
+        acc.uniqueVoters.add(vote.userId);
+        acc.totalTokenAmount = acc.totalTokenAmount.add(vote.tokenAmount);
+        acc.totalVotes += 1;
+        return acc;
+      },
+      {
+        uniqueVoters: new Set<string>(),
+        totalTokenAmount: new Decimal(0),
+        totalVotes: 0
+      }
+    );
+
+    const { votes: _votes, ...repoData } = repo;
+
+    return {
+      ...repoData,
+      totalVotes: stats.totalVotes,
+      totalTokenAmount: stats.totalTokenAmount,
+      uniqueVoters: stats.uniqueVoters.size
+    };
+  });
+
+  const topRepositories = repositoriesWithStats
+    .sort((a, b) => b.totalTokenAmount.comparedTo(a.totalTokenAmount))
+    .slice(0, limit);
+
+  return {
+    repositories: topRepositories
+  };
+};

--- a/src/actions/repository/getTopReposAllTime/schema.ts
+++ b/src/actions/repository/getTopReposAllTime/schema.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+export const getTopReposAllTimeSchema = z.object({
+  limit: z.number().min(1).max(50).optional().default(10),
+});
+
+export type GetTopReposAllTimeInput = z.infer<typeof getTopReposAllTimeSchema>;


### PR DESCRIPTION
This PR introduces a new action to retrieve a list of all-time top repositories.

Motivation:
Users currently only have access to weekly top repositories. This new action will allow users to view repositories that have consistently performed well over the entire history of the platform, providing a more comprehensive view of popular projects.

What changed:
- Added a new directory `src/actions/repository/getTopReposAllTime`.
- Implemented `action.ts`, `logic.ts`, and `schema.ts` within this new directory to handle the fetching and processing of all-time top repositories.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced an all-time Top Repositories ranking, sorted by total token amount.
  * Each repository includes key stats: total token amount, total votes, unique voters, plus core metadata (name, owner, description, links, tags, verification).
  * Supports adjustable result size (1–50) with a default of 10 and input validation to prevent invalid limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->